### PR TITLE
Fix NoClassDefFoundError with InjectedTests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,11 @@
             <groupId>com.github.segator</groupId>
             <artifactId>scaleway-sdk</artifactId>
             <version>0.1-SNAPSHOT</version>
-            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.4</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
htmlunit has a dependency on commons-io:2.4, but
scaleway-api was pulling 1.x, resulting in a
clasloading error.

Stack trace that this commit fixes:

```
org.jvnet.hudson.test.JellyTestSuiteBuilder$JellyTestSuite(org.jvnet.hudson.test.junit.FailedTest) Time elapsed: 0.008 sec  <<< ERROR!
java.lang.NoClassDefFoundError: Could not initialize class com.gargoylesoftware.htmlunit.util.EncodingSniffer
        at com.gargoylesoftware.htmlunit.WebResponse.getContentCharsetOrNull(WebResponse.java:152)
        at com.gargoylesoftware.htmlunit.html.HTMLParser.parse(HTMLParser.java:226)
        at com.gargoylesoftware.htmlunit.html.HTMLParser.parseHtml(HTMLParser.java:199)
        at com.gargoylesoftware.htmlunit.DefaultPageCreator.createHtmlPage(DefaultPageCreator.java:272)
        at com.gargoylesoftware.htmlunit.DefaultPageCreator.createPage(DefaultPageCreator.java:160)
```

Now the build fails because of FindBugs, which is "normal" and fixable.